### PR TITLE
Introduce transform::logging::manager

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -211,6 +211,29 @@ configuration::configuration()
       },
       10_MiB,
       {.min = 1_MiB, .max = 128_MiB})
+  , data_transforms_logging_buffer_capacity_bytes(
+      *this,
+      "data_transforms_logging_buffer_capacity_bytes",
+      "Buffer capacity for transofm logs, per shard. Buffer occupancy is "
+      "calculated as the total size of buffered (i.e. emitted but not yet "
+      "produced) log messages.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      100_KiB,
+      {.min = 100_KiB, .max = 2_MiB})
+  , data_transforms_logging_flush_interval_ms(
+      *this,
+      "data_transforms_logging_flush_interval_ms",
+      "Flush interval for transform logs. When a timer expires, pending logs "
+      "are collected and published to the transform_logs topic.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      500ms)
+  , data_transforms_logging_line_max_bytes(
+      *this,
+      "data_transforms_logging_line_max_bytes",
+      "Transform log lines will be truncate to this length. Truncation occurs "
+      "after any character escaping.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_KiB)
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -74,6 +74,11 @@ struct configuration final : public config_store {
     bounded_property<size_t> data_transforms_per_function_memory_limit;
     property<std::chrono::milliseconds> data_transforms_runtime_limit_ms;
     bounded_property<size_t> data_transforms_binary_max_size;
+    bounded_property<size_t> data_transforms_logging_buffer_capacity_bytes;
+    // TODO(oren): bounded?
+    property<std::chrono::milliseconds>
+      data_transforms_logging_flush_interval_ms;
+    property<size_t> data_transforms_logging_line_max_bytes;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -19,6 +19,7 @@ template<typename ClockType>
 class commit_batcher;
 class processor;
 class probe;
+class log_manager;
 namespace rpc {
 class client;
 class local_service;

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
   NAME transform_logging
   HDRS
     event.h
+    io.h
   SRCS
     event.cc
   DEPS

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -3,8 +3,10 @@ v_cc_library(
   HDRS
     event.h
     io.h
+    logger.h
   SRCS
     event.cc
+    logger.cc
   DEPS
     v::model
 )

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -3,11 +3,14 @@ v_cc_library(
   HDRS
     event.h
     io.h
+    log_manager.h
     logger.h
   SRCS
     event.cc
+    log_manager.cc
     logger.cc
   DEPS
+    v::config
     v::model
 )
 

--- a/src/v/transform/logging/io.h
+++ b/src/v/transform/logging/io.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/record.h"
+#include "transform/logging/event.h"
+
+#pragma once
+
+namespace transform::logging {
+class sink {
+public:
+    sink() = default;
+    sink(const sink&) = delete;
+    sink& operator=(const sink&) = delete;
+    sink(sink&&) = delete;
+    sink& operator=(sink&&) = delete;
+    virtual ~sink() = default;
+
+    // TODO(oren): consider a return code here. but is it actionable?
+    virtual ss::future<>
+    write(model::transform_name_view name, ss::chunked_fifo<iobuf>) = 0;
+};
+} // namespace transform::logging

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/log_manager.h"
+
+#include "base/vassert.h"
+#include "config/configuration.h"
+#include "model/namespace.h"
+#include "strings/utf8.h"
+#include "transform/logging/io.h"
+#include "transform/logging/logger.h"
+
+#include <seastar/core/smp.hh>
+
+namespace transform::logging {
+namespace {
+// totally arbitrary. will be easier to assess once there's actual I/O in the
+// flush fibers
+constexpr int FLUSH_MAX_CONCURRENCY = 10;
+} // namespace
+
+template<typename ClockType>
+manager<ClockType>::manager(model::node_id self, std::unique_ptr<sink> ssink)
+  : _self(self)
+  , _sink(std::move(ssink))
+  , _line_limit_bytes(
+      config::shard_local_cfg().data_transforms_logging_line_max_bytes.bind())
+  , _buffer_limit_bytes(
+      config::shard_local_cfg().data_transforms_logging_buffer_capacity_bytes())
+  , _buffer_low_water_mark(_buffer_limit_bytes / lwm_denom)
+  , _flush_interval_ms(config::shard_local_cfg()
+                         .data_transforms_logging_flush_interval_ms.bind())
+  , _buffer_sem(_buffer_limit_bytes, "Log manager buffer semaphore") {
+    _flush_timer.set_callback(
+      [this]() { ssx::spawn_with_gate(_gate, [this]() { return flush(); }); });
+}
+
+template<typename ClockType>
+manager<ClockType>::~manager() = default;
+
+template<typename ClockType>
+ss::future<> manager<ClockType>::start() {
+    _as = ss::abort_source{};
+    _flush_timer.arm(_flush_interval_ms());
+    return ss::now();
+}
+
+template<typename ClockType>
+ss::future<> manager<ClockType>::stop() {
+    _flush_timer.cancel();
+    _as.request_abort();
+    if (!_gate.is_closed()) {
+        co_await _gate.close();
+    }
+    // TODO(oren): last gasp
+    // ticket: https://github.com/redpanda-data/core-internal/issues/1036
+    // co_return co_await flush();
+}
+
+template<typename ClockType>
+ss::future<> manager<ClockType>::flush() {
+    size_t tot = 0;
+    // TODO(oren): how much parallelism? any at all?
+    co_await ss::max_concurrent_for_each(
+      _event_queue,
+      FLUSH_MAX_CONCURRENCY,
+      ss::coroutine::lambda([this, &tot](auto& pr) -> ss::future<> {
+          auto& [n, q] = pr;
+          if (q.empty()) {
+              co_return;
+          }
+
+          // immediately swap in an empty queue. semaphore units associated
+          // with buffered events are not returned until the corresponding
+          // event is serialized.
+          auto ev = std::exchange(q, queue_t{});
+          ss::chunked_fifo<iobuf> ev_json;
+
+          while (!ev.empty()) {
+              auto e = std::move(ev.front());
+              ev.pop_front();
+              iobuf b;
+              e.event.to_json(model::transform_name_view{n}, b);
+              ev_json.emplace_back(std::move(b));
+
+              // reactor will stall if we try to serialize a whole lot of
+              // messages all at once
+              co_await ss::maybe_yield();
+          }
+
+          // semaphore units for the primary buffer are free at this point.
+
+          // TODO(oren): it might be a good idea to cap the amount of serialized
+          // log data in flight at one time.
+
+          tot += ev_json.size();
+          co_await _sink->write(
+            model::transform_name_view{n}, std::move(ev_json));
+          co_return;
+      }));
+
+    vlog(tlg_log.trace, "Processed {} log events", tot);
+    if (!_as.abort_requested()) {
+        _flush_timer.arm(_flush_interval_ms());
+    }
+    co_return;
+}
+
+template<typename ClockType>
+bool manager<ClockType>::check_lwm() const {
+    return _buffer_sem.available_units() <= _buffer_low_water_mark;
+}
+
+template<typename ClockType>
+void manager<ClockType>::enqueue_log(
+  ss::log_level level,
+  model::transform_name_view transform_name,
+  std::string_view message) {
+    auto msg_len = [this](std::string_view message) -> size_t {
+        return std::min(_line_limit_bytes(), message.size());
+    };
+
+    auto validate_msg =
+      [&msg_len](std::string_view message) -> std::optional<ss::sstring> {
+        auto sub_view = message.substr(0, msg_len(message));
+        if (!is_valid_utf8(sub_view)) {
+            return std::nullopt;
+        } else if (contains_control_character(sub_view)) {
+            // escape control chars and truncate (again, if necessary)
+            auto res = replace_control_chars_in_string(sub_view);
+            return res.substr(0, msg_len(res));
+        }
+        return ss::sstring{sub_view.data(), sub_view.size()};
+    };
+
+    auto get_queue = [this](std::string_view name) {
+        auto res = _event_queue.find(name);
+        if (res == _event_queue.end()) {
+            auto [it, ins] = _event_queue.emplace(
+              ss::sstring{name.data(), name.size()}, queue_t{});
+            if (ins) {
+                return it;
+            }
+            // otherwise something went badly wrong. we'll return the end
+            // iterator and fail the operation
+        }
+        return res;
+    };
+
+    auto it = get_queue(transform_name);
+    if (it == _event_queue.end()) {
+        vlog(tlg_log.warn, "Failed to enqueue transform log: Buffer error");
+        return;
+    }
+
+    auto b = validate_msg(message);
+    if (!b.has_value()) {
+        vlog(
+          tlg_log.debug,
+          "Failed to enqueue transform log: Message validation failed");
+        return;
+    }
+
+    // Annoyingly, we've already allocated the message copy here, since we
+    // need to do control char escaping to determine the final length.
+    // Alternatively, we could have a happy path that avoids allocating
+    // the message until we've acquired sufficient units in cases where
+    // there are no control chars present (happy path).
+    auto units = ss::try_get_units(_buffer_sem, b->size());
+    if (!units) {
+        vlog(tlg_log.debug, "Failed to enqueue transform log: Buffer full");
+        return;
+    }
+
+    it->second.emplace_back(
+      event{_self, event::clock_type::now(), level, std::move(*b)},
+      std::move(*units));
+
+    // if the timer is not armed, we're either shutting down or there's a flush
+    // in progress. in either case, don't bother expediting a flush.
+    if (check_lwm() && _flush_timer.armed()) {
+        _flush_timer.rearm(ClockType::now());
+    }
+}
+
+template class manager<ss::lowres_clock>;
+template class manager<ss::manual_clock>;
+
+} // namespace transform::logging

--- a/src/v/transform/logging/log_manager.h
+++ b/src/v/transform/logging/log_manager.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "model/transform.h"
+#include "ssx/semaphore.h"
+#include "transform/logging/event.h"
+#include "transform/logging/io.h"
+#include "wasm/logger.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+#include <utility>
+
+namespace transform::logging {
+
+template<typename ClockType = ss::lowres_clock>
+class manager {
+    static_assert(
+      std::is_same_v<ClockType, ss::lowres_clock>
+        || std::is_same_v<ClockType, ss::manual_clock>,
+      "Only lowres or manual clocks are supported");
+
+public:
+    manager() = delete;
+    ~manager();
+    manager(const manager&) = delete;
+    manager& operator=(const manager&) = delete;
+    manager(manager&&) = delete;
+    manager& operator=(manager&&) = delete;
+
+    explicit manager(model::node_id self, std::unique_ptr<sink> ssink);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    void enqueue_log(
+      ss::log_level lvl, model::transform_name_view, std::string_view message);
+
+private:
+    // TODO(oren): make configurable?
+    static constexpr double lwm_denom = 10;
+
+    ss::future<> flush();
+    bool check_lwm() const;
+
+    model::node_id _self;
+    std::unique_ptr<transform::logging::sink> _sink;
+    config::binding<size_t> _line_limit_bytes;
+    size_t _buffer_limit_bytes;
+    ssize_t _buffer_low_water_mark;
+    config::binding<std::chrono::milliseconds> _flush_interval_ms;
+    ssx::semaphore _buffer_sem;
+
+    ss::gate _gate;
+    ss::abort_source _as;
+    ss::timer<ClockType> _flush_timer;
+
+    struct log_event {
+        log_event() = delete;
+        explicit log_event(event event, ssx::semaphore_units units)
+          : event(std::move(event))
+          , units(std::move(units)) {}
+        event event;
+        ssx::semaphore_units units;
+    };
+    using queue_t = ss::chunked_fifo<log_event>;
+    struct string_hash {
+        using is_transparent = void;
+        [[nodiscard]] size_t operator()(std::string_view txt) const {
+            return std::hash<std::string_view>{}(txt);
+        }
+        [[nodiscard]] size_t operator()(const ss::sstring& txt) const {
+            return std::hash<ss::sstring>{}(txt);
+        }
+    };
+    absl::flat_hash_map<ss::sstring, queue_t, string_hash, std::equal_to<>>
+      _event_queue;
+};
+
+} // namespace transform::logging

--- a/src/v/transform/logging/logger.cc
+++ b/src/v/transform/logging/logger.cc
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/logger.h"
+
+namespace transform::logging {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
+ss::logger tlg_log("transform_logging");
+} // namespace transform::logging

--- a/src/v/transform/logging/logger.h
+++ b/src/v/transform/logging/logger.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace transform::logging {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern ss::logger tlg_log;
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/CMakeLists.txt
+++ b/src/v/transform/logging/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ rp_test(
   BINARY_NAME transform_logging
   SOURCES
     model_test.cc
+    log_manager_test.cc
   LIBRARIES
     v::transform_logging
     v::transform_logging_test_utils

--- a/src/v/transform/logging/tests/log_manager_test.cc
+++ b/src/v/transform/logging/tests/log_manager_test.cc
@@ -1,0 +1,273 @@
+#include "base/units.h"
+#include "config/configuration.h"
+#include "model/namespace.h"
+#include "model/transform.h"
+#include "strings/utf8.h"
+#include "test_utils/async.h"
+#include "transform/logging/event.h"
+#include "transform/logging/io.h"
+#include "transform/logging/log_manager.h"
+#include "transform/logging/tests/utils.h"
+
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace transform::logging {
+
+namespace {
+
+using namespace std::chrono_literals;
+using manager_t = transform::logging::manager<ss::manual_clock>;
+
+std::chrono::milliseconds flush_interval() {
+    return config::shard_local_cfg()
+      .data_transforms_logging_flush_interval_ms();
+}
+
+void advance_clock(ss::manual_clock::duration dur = flush_interval()) {
+    ss::manual_clock::advance(dur);
+    tests::drain_task_queue().get();
+}
+
+class fake_sink : public transform::logging::sink {
+public:
+    fake_sink() = default;
+
+    ss::future<>
+    write(model::transform_name_view, ss::chunked_fifo<iobuf> events) override {
+        std::move(events.begin(), events.end(), std::back_inserter(_logs));
+        return ss::now();
+    }
+
+    const ss::chunked_fifo<iobuf>& logs() const { return _logs; }
+
+private:
+    ss::chunked_fifo<iobuf> _logs;
+};
+
+} // namespace
+
+class TransformLogManagerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        auto sink = std::make_unique<fake_sink>();
+        _sink = sink.get();
+        _manager = std::make_unique<manager_t>(
+          model::node_id{0}, std::move(sink));
+        start_manager();
+    }
+
+    void SetUp(size_t buffer_capacity, size_t line_max) {
+        config::shard_local_cfg()
+          .data_transforms_logging_buffer_capacity_bytes.set_value(
+            buffer_capacity);
+        config::shard_local_cfg()
+          .data_transforms_logging_line_max_bytes.set_value(line_max);
+        SetUp();
+    }
+
+    void TearDown() override {
+        _sink = nullptr;
+        _manager->stop().get();
+        _manager.reset();
+    }
+
+    void start_manager() { _manager->start().get(); }
+    void stop_manager() { _manager->stop().get(); }
+
+    void enqueue_log(
+      ss::log_level lvl,
+      model::transform_name_view name,
+      std::string_view msg) {
+        _manager->enqueue_log(lvl, name, msg);
+    }
+
+    void enqueue_log(std::string_view msg) {
+        enqueue_log(
+          ss::log_level::info, model::transform_name_view{"foo"}, msg);
+    }
+
+    const ss::chunked_fifo<iobuf>& logs() const { return _sink->logs(); }
+
+private:
+    fake_sink* _sink;
+    std::unique_ptr<manager_t> _manager;
+};
+
+TEST_F(TransformLogManagerTest, EnqueueLogs) {
+    enqueue_log("Hello from some test code!");
+
+    advance_clock();
+    EXPECT_EQ(logs().size(), 1);
+
+    enqueue_log("Hello again from some test code!");
+
+    advance_clock();
+    EXPECT_EQ(logs().size(), 2);
+
+    auto msg = testing::get_message_body(logs().back().copy());
+    EXPECT_TRUE(msg.find("again") != ss::sstring::npos);
+}
+
+TEST_F(TransformLogManagerTest, DISABLED_LastGasp) {
+    constexpr size_t n = 10;
+
+    for (int i = 0; i < n; ++i) {
+        enqueue_log("Hello, World!");
+    }
+
+    EXPECT_EQ(logs().size(), 0);
+
+    stop_manager();
+
+    EXPECT_EQ(logs().size(), n);
+    EXPECT_EQ(testing::get_message_body(logs().back().copy()), "Hello, World!");
+}
+
+TEST_F(TransformLogManagerTest, LargeBuffer) {
+    // This will cause a reactor stall in Debug mode but NOT
+    // in Release
+
+    size_t buf_cap = 1_MiB;
+    size_t line_max = 1_KiB;
+    SetUp(buf_cap, line_max);
+
+    static const std::vector<ss::sstring> names{
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+    };
+
+    auto N = buf_cap / line_max;
+
+    for (int i = 0; i < N; ++i) {
+        enqueue_log(
+          ss::log_level::info,
+          model::transform_name_view{names.at(i % names.size())},
+          ss::sstring(line_max, 'x'));
+    }
+
+    advance_clock();
+
+    EXPECT_EQ(logs().size(), N);
+}
+
+TEST_F(TransformLogManagerTest, BufferLimits) {
+    constexpr size_t buf_cap = 1_KiB;
+    constexpr size_t line_max = 16;
+    constexpr size_t line_cap = buf_cap / line_max;
+
+    SetUp(buf_cap, line_max);
+
+    static const std::vector<ss::sstring> names{
+      "foo",
+      "bar",
+      "baz",
+      "qux",
+    };
+
+    // some logs will get dropped due to buffer limit semaphore
+    // irrespective of transform name
+    for (int i = 0; i < line_cap * 2; ++i) {
+        enqueue_log(
+          ss::log_level::info,
+          model::transform_name_view{names.at(i % 3)},
+          ss::sstring(line_max * 2, 'x'));
+    }
+
+    advance_clock();
+    EXPECT_EQ(logs().size(), line_cap);
+
+    // we should have full capacity now
+    for (int i = 0; i < line_cap; ++i) {
+        enqueue_log(
+          ss::log_level::info,
+          model::transform_name_view{names.at(i % names.size())},
+          ss::sstring(line_max * 2, 'x'));
+    }
+
+    advance_clock();
+    EXPECT_EQ(logs().size(), line_cap * 2);
+}
+
+TEST_F(TransformLogManagerTest, LwmTriggerFlush) {
+    constexpr size_t buf_cap = 1000;
+    constexpr size_t line_max = buf_cap * 8 / 10;
+    SetUp(buf_cap, line_max);
+
+    constexpr size_t big_line = line_max;
+    constexpr size_t small_line = line_max / 7;
+
+    // this shouldn't trigger lwm
+    enqueue_log(ss::sstring(big_line, 'x'));
+    EXPECT_TRUE(logs().empty());
+    advance_clock(1ms);
+    EXPECT_TRUE(logs().empty());
+
+    // this one _should_ trigger lwm
+    enqueue_log(ss::sstring(small_line, 'x'));
+    EXPECT_TRUE(logs().empty());
+    // any duration really. we should flush immediately.
+    advance_clock(1ms);
+    EXPECT_EQ(logs().size(), 2);
+
+    // we should have full capacity now
+    enqueue_log(ss::sstring(line_max + small_line, 'x'));
+    advance_clock();
+    EXPECT_EQ(logs().size(), 3);
+}
+
+TEST_F(TransformLogManagerTest, MessageTruncation) {
+    constexpr size_t line_max = 16;
+    // arbitrary buffer cap, don't care, but set the line max to something
+    // convenient and small
+    SetUp(1_KiB, line_max);
+
+    enqueue_log(ss::sstring(line_max * 2, 'x'));
+    advance_clock();
+    auto msg = testing::get_message_body(logs().front().copy());
+    EXPECT_EQ(msg.length(), line_max);
+
+    // test that truncation occurs _after_ control char escaping
+    ss::sstring in_msg(line_max, char{0x7f});
+    auto escaped = replace_control_chars_in_string(in_msg);
+    EXPECT_GT(escaped.length(), line_max);
+
+    enqueue_log(in_msg);
+    advance_clock();
+    msg = testing::get_message_body(logs().back().copy());
+    EXPECT_EQ(msg.length(), line_max);
+    EXPECT_EQ(msg, escaped.substr(0, line_max));
+}
+
+TEST_F(TransformLogManagerTest, IllegalMessages) {
+    std::string bad_utf8_msg = "FOO\xc3\x28";
+    const std::array<char, 8> control_char_msg{
+      'f', 'o', 'o', 0x01, 0x02, 0x03, 0x04, 0x00};
+
+    enqueue_log(
+      ss::log_level::info, model::transform_name_view{"foo"}, bad_utf8_msg);
+
+    // invalid UTF-8 message is dropped
+    advance_clock();
+    EXPECT_EQ(logs().size(), 0);
+
+    enqueue_log(
+      ss::log_level::info,
+      model::transform_name_view{"foo"},
+      control_char_msg.data());
+
+    // control char message is properly escaped
+    advance_clock();
+    EXPECT_EQ(logs().size(), 1);
+
+    auto msg = testing::get_message_body(logs().front().copy());
+    EXPECT_EQ(msg, replace_control_chars_in_string(control_char_msg.data()));
+}
+
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/utils.cc
+++ b/src/v/transform/logging/tests/utils.cc
@@ -27,4 +27,9 @@ json::Document parse_json(iobuf resp) {
     return doc;
 }
 
+std::string get_message_body(iobuf msg) {
+    auto doc = parse_json(std::move(msg));
+    return {doc["body"].GetString()};
+}
+
 } // namespace transform::logging::testing

--- a/src/v/transform/logging/tests/utils.h
+++ b/src/v/transform/logging/tests/utils.h
@@ -14,8 +14,11 @@
 #include "bytes/iobuf.h"
 #include "json/document.h"
 
+#include <string>
+
 namespace transform::logging::testing {
 
 json::Document parse_json(iobuf resp);
+std::string get_message_body(iobuf);
 
 } // namespace transform::logging::testing


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces `transform::logging::manager` whose primary responsibility is to buffer transform logs, periodically flushing them to some `transform::logging::sink` as `chunked_fifo<iobuf>` of JSON-serialized OpenTelemetry-compatible log events.

Closes https://github.com/redpanda-data/core-internal/issues/1035

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
