### PR TITLE
Csc/noticket/abs oauth test

### DIFF
--- a/src/v/cloud_io/remote.cc
+++ b/src/v/cloud_io/remote.cc
@@ -896,7 +896,7 @@ ss::future<upload_result> remote::delete_object_batch(
         if (res) {
             if (!res.value().undeleted_keys.empty()) {
                 vlog(
-                  ctxlog.debug,
+                  ctxlog.info,
                   "{} objects were not deleted by plural delete; first "
                   "failure: {{key: {}, reason:{}}}",
                   res.value().undeleted_keys.size(),

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -21,9 +21,8 @@ apply_abs_oauth_credentials::apply_abs_oauth_credentials(
 std::error_code apply_abs_oauth_credentials::add_auth(
   http::client::request_header& header) const {
     auto token = _oauth_token();
-    // x-ms-version requests a specific version for the abs api, the hardcoded
-    // value is the one we test
-    header.set("x-ms-version", azure_storage_api_version);
+    // x-ms-version is set by abs_request_creator::add_auth, not here,
+    // because batch sub-requests must omit it before signing.
     auto iso_ts = _timesource.format_http_datetime();
     header.set("x-ms-date", {iso_ts.data(), iso_ts.size()});
     header.insert(

--- a/src/v/cloud_roles/azure_vm_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_vm_refresh_impl.cc
@@ -35,36 +35,19 @@ std::ostream& azure_vm_refresh_impl::print(std::ostream& os) const {
 ss::future<api_response> azure_vm_refresh_impl::fetch_credentials() {
     auto client_id_opt = config::shard_local_cfg()
                            .cloud_storage_azure_managed_identity_id.value();
-    if (unlikely(!client_id_opt.has_value())) {
-        // This implementation requires client_id from config to be set.
-        // Strictly speaking, IMDS service does not require it if there is only
-        // a system-assigned managed identity or only one user-assigned managed
-        // identity but it would be brittle to not specify it, it could break if
-        // the user added a new one. This verification is also performed in
-        // admin/server.cc::patch_cluster_config
-        vlog(
-          clrl_log.error,
-          "missing cloud_storage_azure_managed_identity_id in config");
-        // return value is not a perfect match but it works
-        co_return api_request_error{
-          .status = boost::beast::http::status::bad_request,
-          .reason = "missing cloud_storage_azure_managed_identity_id",
-          .error_kind = api_request_error_kind::failed_abort};
+    // IMDS does not require client_id when the VM has a single managed
+    // identity (system-assigned or one user-assigned). Include it only
+    // when explicitly configured.
+    ss::sstring target = "/metadata/identity/oauth2/token?"
+                         "api-version=2018-02-01"
+                         "&resource=https%3A%2F%2Fstorage.azure.com%2F";
+    if (client_id_opt.has_value()) {
+        target += fmt::format("&client_id={}", client_id_opt.value());
     }
 
-    // performs this GET
-    // 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://storage.azure.com/&client_id={$client_id}'
-    // to the vm-local IMDS
     auto req = http::client::request_header{};
     req.method(boost::beast::http::verb::get);
-    // TODO fix deps and use boost::url
-    req.target(
-      fmt::format(
-        "/metadata/identity/oauth2/token?"
-        "api-version=2018-02-01"
-        "&resource=https%3A%2F%2Fstorage.azure.com%2F"
-        "&client_id={}",
-        client_id_opt.value()));
+    req.target(std::string_view{target});
     req.set("Metadata", "true");
 
     co_return co_await make_request(

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -111,8 +111,9 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer a-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        // x-ms-version is set by abs_request_creator::add_auth, not by
+        // the credentials layer.
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 
     applier.reset_creds(
@@ -122,7 +123,6 @@ BOOST_AUTO_TEST_CASE(test_azure_oauth_headers) {
         bh::request_header<> h{};
         BOOST_REQUIRE(!applier.add_auth(h));
         BOOST_REQUIRE_EQUAL(h.at("Authorization"), "Bearer second-token");
-        BOOST_REQUIRE_EQUAL(
-          h.at("x-ms-version"), cloud_roles::azure_storage_api_version);
+        BOOST_REQUIRE(h.find("x-ms-version") == h.end());
     }
 }

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -559,7 +559,12 @@ ss::future<upload_result> remote::delete_objects(
         std::move(keys),
         parent,
         make_notify_cb(api_activity_type::segment_delete, parent))
-      .then([h = std::move(holder)](upload_result r) { return r; });
+      .then([this, h = std::move(holder)](upload_result r) {
+          if (r == upload_result::failed && is_batch_delete_supported()) {
+              _probe.batch_delete_error();
+          }
+          return r;
+      });
 }
 
 template ss::future<upload_result>

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -147,6 +147,10 @@ remote_probe::remote_probe(
               sm::description(
                 "Number of times backoff was applied during "
                 "controller snapshot uploads")),
+            sm::make_counter(
+              "batch_delete_errors",
+              [this] { return _cnt_batch_delete_errors; },
+              sm::description("Number of failed batch delete requests")),
             sm::make_histogram(
               "client_acquisition_latency",
               [this] {

--- a/src/v/cloud_storage/remote_probe.h
+++ b/src/v/cloud_storage/remote_probe.h
@@ -228,6 +228,8 @@ public:
 
     void index_download() { ++_cnt_index_downloads; }
 
+    void batch_delete_error() { ++_cnt_batch_delete_errors; }
+
     auto client_acquisition() {
         return _client_acquisition_latency.auto_measure();
     }
@@ -316,6 +318,9 @@ private:
     uint64_t _cnt_topic_mount_manifest_uploads{0};
     /// Number of topic_mount manifest downloads
     uint64_t _cnt_topic_mount_manifest_downloads{0};
+    /// Number of batch deletes that got a successful HTTP response but
+    /// reported undeleted keys
+    uint64_t _cnt_batch_delete_errors{0};
 
     hist_t _client_acquisition_latency;
     hist_t _segment_download_latency;

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -234,18 +234,28 @@ parse_batch_delete_response(
     while ((part = parts.get_part()).has_value()) {
         iobuf_parser part_parser{std::move(part).value()};
         auto mime = util::mime_header::from(part_parser);
+        // Parse the sub-response before checking Content-ID so error
+        // details are available for logging even when correlation fails.
+        // Note: this throws on truly malformed parts (not valid HTTP),
+        // which will fail the entire batch. That's acceptable — if the
+        // response is so broken we can't parse it, there's nothing
+        // useful to extract.
+        auto subrequest = util::multipart_subresponse::from(part_parser);
         auto maybe_content_id = mime.content_id<size_t>(convert_content_id);
         if (!maybe_content_id.has_value()) {
-            vlog(
-              abs_log.debug,
-              "batch_delete_response: MIME header missing 'Content-ID' from "
-              "batch response, skipping part");
+            auto err = subrequest.error(error_code_name);
+            auto lvl = err.has_value() ? ss::log_level::warn
+                                       : ss::log_level::debug;
+            vlogl(
+              abs_log,
+              lvl,
+              "batch_delete_response: MIME header missing 'Content-ID' "
+              "from batch response, skipping part. Sub-response "
+              "error: {}",
+              err);
             continue;
         }
         content_ids_seen.insert(maybe_content_id.value());
-        // having stripped off the leading MIME headers, we should have a
-        // complete HTTP response at the front of the parser
-        auto subrequest = util::multipart_subresponse::from(part_parser);
 
         if (maybe_content_id.value() >= keys.size()) {
             vlog(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -712,18 +712,28 @@ parse_gcs_batch_delete_response(
     while ((part = parts.get_part()).has_value()) {
         iobuf_parser part_parser{std::move(part).value()};
         auto mime = util::mime_header::from(part_parser);
+        // Parse the sub-response before checking Content-ID so error
+        // details are available for logging even when correlation fails.
+        // Note: this throws on truly malformed parts (not valid HTTP),
+        // which will fail the entire batch. That's acceptable — if the
+        // response is so broken we can't parse it, there's nothing
+        // useful to extract.
+        auto subrequest = util::multipart_subresponse::from(part_parser);
         auto maybe_content_id = mime.content_id<size_t>(convert_content_id);
         if (!maybe_content_id.has_value()) {
-            vlog(
-              s3_log.debug,
-              "MIME header missing 'Content-ID' from batch response, skipping "
-              "part");
+            auto err = subrequest.error(parse_gcs_error_reason);
+            auto lvl = err.has_value() ? ss::log_level::warn
+                                       : ss::log_level::debug;
+            vlogl(
+              s3_log,
+              lvl,
+              "batch_delete_response: MIME header missing 'Content-ID' "
+              "from batch response, skipping part. Sub-response "
+              "error: {}",
+              err);
             continue;
         }
         content_ids_seen.insert(maybe_content_id.value());
-        // having stripped off the leading MIME headers, we should have a
-        // complete HTTP response at the front of the parser
-        auto subrequest = util::multipart_subresponse::from(part_parser);
 
         if (maybe_content_id.value() >= keys.size()) {
             vlog(

--- a/src/v/cloud_storage_clients/tests/abs_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/abs_client_test.cc
@@ -459,6 +459,52 @@ TEST_F(abs_client_fixture, test_batch_delete_not_found) {
     EXPECT_TRUE(result.value().undeleted_keys.empty());
 }
 
+// Verify that batch delete sub-requests do not include x-ms-version.
+// Azure rejects sub-requests with this header
+// (SubRequestCannotHaveVersionHeader). This was a bug when using OAuth
+// credentials, whose add_auth previously set x-ms-version unconditionally.
+TEST(abs_batch_delete_subrequest, no_version_header_in_subrequests) {
+    auto conf = make_test_configuration("test-version-check");
+    auto oauth_creds = ss::make_lw_shared(
+      cloud_roles::make_credentials_applier(
+        cloud_roles::abs_oauth_credentials{
+          .oauth_token = cloud_roles::oauth_token_str{"test-token"}}));
+
+    abs_request_creator requestor(conf, oauth_creds);
+    auto keys = chunked_vector<object_key>{
+      object_key{"blob0"}, object_key{"blob1"}};
+    auto result = requestor.make_batch_delete_request(
+      plain_bucket_name{"container"}, keys);
+    ASSERT_TRUE(result.has_value());
+
+    auto& [header, body_stream] = result.value();
+
+    // The outer request header should have x-ms-version
+    auto outer_version = header.find("x-ms-version");
+    EXPECT_NE(outer_version, header.end());
+
+    // Read the body and check that sub-requests do not contain x-ms-version
+    auto body_buf = body_stream.read().get();
+    auto body_str = ss::sstring(body_buf.get(), body_buf.size());
+
+    // Split on boundary to get individual sub-requests. Each sub-request
+    // after the MIME headers contains an HTTP request line and headers.
+    // x-ms-version must not appear in any sub-request.
+    size_t pos = 0;
+    size_t subrequest_count = 0;
+    while ((pos = body_str.find("DELETE ", pos)) != ss::sstring::npos) {
+        auto end = body_str.find("\r\n\r\n", pos);
+        auto subrequest_headers = body_str.substr(
+          pos, end != ss::sstring::npos ? end - pos : ss::sstring::npos);
+        EXPECT_EQ(subrequest_headers.find("x-ms-version"), ss::sstring::npos)
+          << "Sub-request " << subrequest_count
+          << " contains x-ms-version header";
+        ++subrequest_count;
+        pos += 7;
+    }
+    EXPECT_EQ(subrequest_count, keys.size());
+}
+
 TEST_F(abs_client_fixture, test_batch_delete_server_error) {
     set_up("test-servererror");
     auto keys = chunked_vector<object_key>{object_key{"key1"}};

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1040,6 +1040,48 @@ TEST(FindMultipartBoundary, EmptyBoundaryParameter) {
       result.error(), testing::HasSubstr("Boundary missing from multipart"));
 }
 
+TEST(FindMultipartBoundary, TrailingParameterAfterBoundary) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      "multipart/mixed; boundary=batch_abc123; charset=utf-8");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
+TEST(FindMultipartBoundary, TrailingParameterAfterQuotedBoundary) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      R"(multipart/mixed; boundary="batch_abc123"; charset=utf-8)");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
+TEST(FindMultipartBoundary, BoundaryNotFirstParameter) {
+    using namespace cloud_storage_clients;
+
+    http::client::response_header headers;
+    headers.insert(
+      boost::beast::http::field::content_type,
+      "multipart/mixed; charset=utf-8; boundary=batch_abc123");
+
+    auto result = util::find_multipart_boundary(headers);
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(result.value(), "batch_abc123");
+}
+
 // ============================================================================
 // Preamble handling tests
 //

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -284,6 +284,32 @@ TEST(MultipartParser, EmptyBuffer) {
     EXPECT_FALSE(part.has_value());
 }
 
+TEST(MultipartParser, PartialDelimiterOverlapWithRealBoundary) {
+    using namespace cloud_storage_clients;
+
+    // The part body contains "--b-" which partially matches the delimiter
+    // "--boundary". The third '-' breaks the match at _delim[3]='o' but is
+    // also _delim[0]='-', so the parser must re-check it as the potential
+    // start of a new delimiter match.
+    std::string_view multipart_data = "--boundary\r\n"
+                                      "Content-ID: 0\r\n"
+                                      "\r\n"
+                                      "data--b-more\r\n"
+                                      "--boundary--\r\n";
+
+    auto buf = iobuf::from(multipart_data);
+
+    util::multipart_response_parser parser(
+      std::move(buf), ss::sstring("--boundary"));
+
+    auto part1 = parser.get_part();
+    ASSERT_TRUE(part1.has_value());
+    EXPECT_THAT(
+      part1.value().linearize_to_string(), testing::HasSubstr("data--b-more"));
+
+    EXPECT_FALSE(parser.get_part().has_value());
+}
+
 // ============================================================================
 // multipart_subresponse tests
 // ============================================================================

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -570,12 +570,32 @@ find_multipart_boundary(const http::client::response_header& headers) {
         if (n_eq != 1) {
             boundary = {};
         }
-        // Remove quotes if present
+        // Remove quotes if present. Per RFC 2045 a parameter value is
+        // either a token or a quoted-string.
         if (!boundary.empty() && boundary.front() == '"') {
             boundary = boundary.substr(1);
-        }
-        if (!boundary.empty() && boundary.back() == '"') {
-            boundary = boundary.substr(0, boundary.size() - 1);
+            // The closing quote marks the end of the value.
+            if (auto q = boundary.find('"'); q != boundary.npos) {
+                boundary = boundary.substr(0, q);
+            } else {
+                // Malformed: opening quote with no closing quote.
+                // Trim at semicolon as a fallback.
+                if (auto sc = boundary.find(';'); sc != boundary.npos) {
+                    boundary = boundary.substr(0, sc);
+                }
+            }
+        } else {
+            // Unquoted token: trim at the first semicolon (start of the
+            // next Content-Type parameter) per RFC 2045 §5.1.
+            if (auto sc = boundary.find(';'); sc != boundary.npos) {
+                boundary = boundary.substr(0, sc);
+            }
+            // Also strip any trailing whitespace that may precede the
+            // semicolon or end of header.
+            while (!boundary.empty()
+                   && (boundary.back() == ' ' || boundary.back() == '\t')) {
+                boundary = boundary.substr(0, boundary.size() - 1);
+            }
         }
     }
     if (boundary.empty()) {

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -389,9 +389,24 @@ std::optional<iobuf> multipart_response_parser::get_part() {
             continue;
         }
         // unlikely, but we may have skipped some bytes that appeared to be
-        // part of a delimiter.
-        part_len += delim_idx + 1;
+        // part of a delimiter. Re-check the current character against the
+        // start of the delimiter, as in advance_to_first_boundary.
+        // NOTE: this is not full string search — it only handles overlap with
+        // _delim[0], not longer prefix/suffix overlaps. Fine in practice
+        // because RFC 2046 boundaries start with "--" and real server
+        // boundaries don't have repeated prefixes.
+        auto matched_prefix_len = delim_idx;
         delim_idx = 0;
+        if (c == _delim[0]) {
+            // The character that broke the match is also the start of a
+            // potential new match. Only commit the previously matched
+            // prefix to the part length; keep c out of the content until
+            // we know whether this new match succeeds.
+            part_len += matched_prefix_len;
+            delim_idx = 1;
+            continue;
+        }
+        part_len += matched_prefix_len + 1;
         auto [is_lf, _] = line_feed.try_put(c);
         // eat up any leading CRLFs so the resulting part starts on text
         if (!part_start.has_value()) [[unlikely]] {

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -714,14 +714,14 @@ class SISettings:
                     ][1]
 
         elif self.cloud_storage_type == CloudStorageType.ABS:
-            self.cloud_storage_azure_shared_key = self.ABS_AZURITE_KEY
             self.cloud_storage_azure_storage_account = self.ABS_AZURITE_ACCOUNT
-
             self._cloud_storage_azure_container = f"panda-container-{uuid.uuid1()}"
             self.cloud_storage_api_endpoint = (
                 f"{self.cloud_storage_azure_storage_account}.blob.localhost"
             )
             self.cloud_storage_api_endpoint_port = AZURITE_PORT
+            self.cloud_storage_credentials_source = cloud_storage_credentials_source
+            self.cloud_storage_azure_shared_key = self.ABS_AZURITE_KEY
         else:
             assert False, (
                 f"Unexpected value provided for 'cloud_storage_type' injected arg: {self.cloud_storage_type}"
@@ -839,6 +839,41 @@ class SISettings:
                 self.addressing_style = S3AddressingStyle.VIRTUAL
 
     def _load_abs_context(self, logger: Logger, test_context: TestContext) -> None:
+        # Check both globals and the value already set by __init__ (a test
+        # may request a specific credential source via SISettings params).
+        cred_source = test_context.globals.get(
+            self.GLOBAL_CLOUD_STORAGE_CRED_SOURCE_KEY,
+            self.cloud_storage_credentials_source,
+        )
+
+        if cred_source in (
+            "azure_aks_oidc_federation",
+            "azure_vm_instance_metadata",
+        ):
+            storage_account = test_context.globals.get(
+                self.GLOBAL_ABS_STORAGE_ACCOUNT, None
+            )
+            if storage_account:
+                logger.info("Running on Azure with OAuth credentials")
+                self.cloud_storage_credentials_source = cred_source
+                self.cloud_storage_azure_storage_account = storage_account
+                # Keep the shared key for the ducktape ABSClient (container
+                # management) but Redpanda itself uses OAuth — the shared
+                # key is omitted from the Redpanda config by update_rp_conf
+                # when cloud_storage_credentials_source != config_file.
+                shared_key = test_context.globals.get(self.GLOBAL_ABS_SHARED_KEY, None)
+                if shared_key:
+                    self.cloud_storage_azure_shared_key = shared_key
+                self.cloud_storage_disable_tls = False
+                self.cloud_storage_api_endpoint_port = 443
+                self.endpoint_url = None
+                self.cloud_storage_trust_file = None
+            else:
+                logger.info("Running locally against Azurite with OAuth")
+                # Local Azurite settings already configured in __init__
+            return
+
+        # Existing shared key path
         storage_account = test_context.globals.get(
             self.GLOBAL_ABS_STORAGE_ACCOUNT, None
         )
@@ -957,7 +992,17 @@ class SISettings:
                 self.cloud_storage_azure_storage_account
             )
             conf["cloud_storage_azure_container"] = self._cloud_storage_azure_container
-            conf["cloud_storage_azure_shared_key"] = self.cloud_storage_azure_shared_key
+            if self.cloud_storage_azure_shared_key:
+                conf["cloud_storage_azure_shared_key"] = (
+                    self.cloud_storage_azure_shared_key
+                )
+            if (
+                hasattr(self, "cloud_storage_credentials_source")
+                and self.cloud_storage_credentials_source != "config_file"
+            ):
+                conf["cloud_storage_credentials_source"] = (
+                    self.cloud_storage_credentials_source
+                )
 
         conf["log_segment_size"] = self.log_segment_size
         if self.log_segment_size_min is not None:

--- a/tests/rptest/tests/abs_oauth_deletion_test.py
+++ b/tests/rptest/tests/abs_oauth_deletion_test.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.context.cloud_storage import CloudStorageType
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import MetricsEndpoint, SISettings, get_cloud_storage_type
+from rptest.tests.redpanda_test import RedpandaTest
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+
+class ABSOAuthDeletionTest(RedpandaTest):
+    """
+    Verify that tiered storage GC works correctly when Redpanda
+    authenticates to Azure Blob Storage via OAuth (AKS OIDC federation).
+
+    This catches bugs like x-ms-version leaking into batch delete
+    sub-requests, which only manifests with OAuth credentials.
+
+    CDT-only: skipped when not running against real Azure (Azurite
+    does not support Bearer auth).
+    """
+
+    segment_size = 1024 * 1024  # 1 MiB
+    topics = [TopicSpec(partition_count=1, replication_factor=3)]
+
+    def __init__(self, test_context):
+        # Inject ABS type for SISettings. On non-Azure environments the
+        # @matrix decorator produces zero variants so __init__ never runs.
+        if (
+            not hasattr(test_context, "injected_args")
+            or test_context.injected_args is None
+        ):
+            test_context.injected_args = {}
+        test_context.injected_args["cloud_storage_type"] = CloudStorageType.ABS
+
+        si_settings = SISettings(
+            test_context,
+            cloud_storage_credentials_source="azure_vm_instance_metadata",
+            log_segment_size=self.segment_size,
+            fast_uploads=True,
+        )
+        extra_rp_conf = {
+            "cloud_storage_housekeeping_interval_ms": 5000,
+        }
+
+        super().__init__(
+            test_context=test_context,
+            si_settings=si_settings,
+            extra_rp_conf=extra_rp_conf,
+            num_brokers=3,
+        )
+
+    @cluster(num_nodes=4)  # 3 brokers + 1 kgo-verifier
+    @matrix(
+        cloud_storage_type=get_cloud_storage_type(
+            applies_only_on=[CloudStorageType.ABS], docker_use_arbitrary=True
+        )
+    )
+    def test_batch_delete_with_oauth(self, cloud_storage_type):
+        """Produce data, trigger retention, verify segments are deleted
+        without batch delete partial failures."""
+        topic = self.topics[0].name
+        rpk = RpkTool(self.redpanda)
+
+        # Set tight retention to trigger GC quickly
+        rpk.alter_topic_config(topic, "retention.bytes", str(self.segment_size * 3))
+        rpk.alter_topic_config(
+            topic, "retention.local.target.bytes", str(self.segment_size * 2)
+        )
+
+        # Produce enough data to create multiple cloud segments
+        msg_size = 1024
+        msg_count = self.segment_size * 10 // msg_size
+        KgoVerifierProducer.oneshot(
+            self.test_context,
+            self.redpanda,
+            topic,
+            msg_size=msg_size,
+            msg_count=msg_count,
+        )
+
+        # Wait for segments to be uploaded to cloud storage
+        def uploaded_enough():
+            return (
+                self.redpanda.metric_sum("vectorized_cloud_storage_successful_uploads")
+                > 5
+            )
+
+        wait_until(
+            uploaded_enough,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg="Segments not uploaded to cloud storage",
+        )
+
+        # Wait for GC to delete at least one segment.
+        def segments_deleted():
+            n = self.redpanda.metric_sum(
+                "redpanda_cloud_storage_deleted_segments_total",
+                metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS,
+            )
+            self.logger.info(f"deleted_segments_total = {n}")
+            return n > 0
+
+        wait_until(
+            segments_deleted,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="GC did not delete any cloud segments",
+        )
+
+        # The key assertion: no batch delete partial failures.
+        # This metric fires when the HTTP request succeeds but the
+        # multipart response indicates undeleted keys -- the exact
+        # failure mode caused by x-ms-version leaking into sub-requests.
+        failures = self.redpanda.metric_sum(
+            "vectorized_cloud_storage_batch_delete_errors"
+        )
+        assert failures == 0, (
+            f"Expected 0 batch delete partial failures, got {failures}"
+        )

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -184,7 +184,7 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         return all_uploads_done(self.rpk, self.topic, self.redpanda, self.logger)
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=get_cloud_storage_type()[0:1])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_reset(self, cloud_storage_type):
         msg_count_before_reset = 50 * (self.segment_size // 2056)
         producer = KgoVerifierProducer(

--- a/tools/type-checking/type-check-strictness.json
+++ b/tools/type-checking/type-check-strictness.json
@@ -68,6 +68,7 @@
         "rptest/services/serde_client.py",
         "rptest/services/storage_failure_injection.py",
         "rptest/services/tc_netem.py",
+        "rptest/tests/abs_oauth_deletion_test.py",
         "rptest/tests/acl_upgrade_test.py",
         "rptest/tests/admin_operations_test.py",
         "rptest/tests/archival_test.py",


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

CDT Azure OAuth Test — Infrastructure Requirements

  The ABSOAuthDeletionTest needs the CDT Azure VM's managed identity to have blob data access on the storage account used for testing.

  What's needed:

  Assign the Storage Blob Data Contributor role to the VM's system-assigned managed identity on the CDT storage account.

  Azure CLI (run by someone with Owner/User Access Administrator on the storage account):

  ### Get the VM's managed identity principal ID
  VM_PRINCIPAL_ID=$(az vm show \
    --resource-group <CDT_RESOURCE_GROUP> \
    --name <CDT_VM_NAME> \
    --query identity.principalId -o tsv)

  ### Get the storage account resource ID
  STORAGE_ID=$(az storage account show \
    --resource-group <CDT_RESOURCE_GROUP> \
    --name <CDT_STORAGE_ACCOUNT> \
    --query id -o tsv)

  ### Assign the role
  az role assignment create \
    --assignee-object-id "$VM_PRINCIPAL_ID" \
    --assignee-principal-type ServicePrincipal \
    --role "Storage Blob Data Contributor" \
    --scope "$STORAGE_ID"

  If the CDT uses multiple VMs (one per Redpanda node), each VM's identity needs the role. If they share a single user-assigned managed identity, assign it once.

  What's already working:
  - Redpanda starts with cloud_storage_credentials_source: azure_vm_instance_metadata
  - IMDS token acquisition succeeds (no client_id needed — single identity)
  - Token is sent to Azure Storage with Bearer auth
  - Azure rejects with AuthorizationPermissionMismatch — purely a permissions issue

  What the test validates once permissions are granted:
  - OAuth token acquisition via VM managed identity
  - Tiered storage uploads + GC with OAuth credentials
  - Batch delete without x-ms-version in sub-requests (the original bug)
  - batch_delete_errors metric stays at 0

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v26.1.x
- [ ] v25.3.x
- [ ] v25.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
